### PR TITLE
fix Tensor.numpy()[0] to float(Tensor) to adapt 0D

### DIFF
--- a/AdvBox/examples/objectdetector/ppdet/modeling/tests/test_yolov3_loss.py
+++ b/AdvBox/examples/objectdetector/ppdet/modeling/tests/test_yolov3_loss.py
@@ -356,8 +356,8 @@ class TestYolov3LossOp(unittest.TestCase):
             x, t, gtbox, anchor, self.downsample_ratio, self.scale_x_y)
         for k in yolo_loss2:
             self.assertAlmostEqual(
-                yolo_loss1[k].numpy()[0],
-                yolo_loss2[k].numpy()[0],
+                float(yolo_loss1[k]),
+                float(yolo_loss2[k]),
                 delta=1e-2,
                 msg=k)
 

--- a/AdvBox/obj_detection/ppdet/modeling/tests/test_yolov3_loss.py
+++ b/AdvBox/obj_detection/ppdet/modeling/tests/test_yolov3_loss.py
@@ -356,8 +356,8 @@ class TestYolov3LossOp(unittest.TestCase):
             x, t, gtbox, anchor, self.downsample_ratio, self.scale_x_y)
         for k in yolo_loss2:
             self.assertAlmostEqual(
-                yolo_loss1[k].numpy()[0],
-                yolo_loss2[k].numpy()[0],
+                float(yolo_loss1[k]),
+                float(yolo_loss2[k]),
                 delta=1e-2,
                 msg=k)
 

--- a/AdvBox/text_recognition/ppocr/postprocess/rec_postprocess.py
+++ b/AdvBox/text_recognition/ppocr/postprocess/rec_postprocess.py
@@ -891,7 +891,7 @@ class VLLabelDecode(BaseRecLabelDecode):
             ) + length[i])].topk(1)[0][:, 0]
             preds_prob = paddle.exp(
                 paddle.log(preds_prob).sum() / (preds_prob.shape[0] + 1e-6))
-            text.append((preds_text, preds_prob.numpy()[0]))
+            text.append((preds_text, float(preds_prob))
         if label is None:
             return text
         label = self.decode(label)


### PR DESCRIPTION
有些Tensor正确的语义为0D Tensor，其shape为[]，当前使用了shape为[1]替代，也就是向量Tensor：

在升级为0D后，Tensor.numpy()[0] 的写法不再使用，将其改变为 float(Tensor) 的写法，兼容升级前后。